### PR TITLE
✨ Crawler para site dos Correios

### DIFF
--- a/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/config/SswCrawlerConfiguration.kt
+++ b/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/config/SswCrawlerConfiguration.kt
@@ -1,6 +1,6 @@
 package dev3.estouropilha.trackr.backend.config
 
-import dev3.estouropilha.trackr.backend.crawlers.ssw.SswCrawler
+import dev3.estouropilha.trackr.backend.crawlers.SswCrawler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 

--- a/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/controllers/EntregasController.kt
+++ b/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/controllers/EntregasController.kt
@@ -1,6 +1,6 @@
 package dev3.estouropilha.trackr.backend.controllers
 
-import dev3.estouropilha.trackr.backend.crawlers.ssw.SswCrawler
+import dev3.estouropilha.trackr.backend.crawlers.SswCrawler
 import dev3.estouropilha.trackr.backend.dto.EntregaDto
 import dev3.estouropilha.trackr.backend.dto.MovimentacaoDto
 import io.swagger.annotations.Api

--- a/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/crawlers/CorreiosCrawler.kt
+++ b/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/crawlers/CorreiosCrawler.kt
@@ -1,0 +1,39 @@
+package dev3.estouropilha.trackr.backend.crawlers
+
+import dev3.estouropilha.trackr.backend.models.Entrega
+import dev3.estouropilha.trackr.backend.models.Movimentacao
+import org.jsoup.Jsoup
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.regex.Pattern
+
+class CorreiosCrawler {
+    fun consultarEntregas(codigoRastreio: String): Entrega {
+        val movimentacoes = Jsoup.connect("https://www2.correios.com.br/sistemas/rastreamento/ctrl/ctrlRastreamento.cfm")
+                .data("acao", "track")
+                .data("objetos", codigoRastreio)
+                .data("btnPesq", "Buscar")
+                .followRedirects(true)
+                .post()
+                .select("table.listEvent.sro")
+                .map { tabela ->
+                    val (data, local) =
+                            tabela.select(".sroDtEvent")
+                                    .text()
+                                    .split("""(?<=\d{2}\/\d{2}\/\d{4} \d{2}:\d{2})""".toRegex())
+                                    .map { it.trim() }
+                                    .filter { !it.isBlank() }
+
+                    val lbEvent = tabela.select(".sroLbEvent")
+
+                    Movimentacao(
+                            lbEvent.select("strong").text(),
+                            LocalDateTime.parse(data, DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")),
+                            local,
+                            Regex("(?<=<br>)[\\s\\S]*").find(lbEvent.html())?.groupValues?.first() ?: ""
+                    )
+                }
+        
+        return Entrega(movimentacoes)
+    }
+}

--- a/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/crawlers/SswCrawler.kt
+++ b/backend/src/main/kotlin/dev3/estouropilha/trackr/backend/crawlers/SswCrawler.kt
@@ -1,4 +1,4 @@
-package dev3.estouropilha.trackr.backend.crawlers.ssw
+package dev3.estouropilha.trackr.backend.crawlers
 
 import dev3.estouropilha.trackr.backend.models.Entrega
 import dev3.estouropilha.trackr.backend.models.Movimentacao
@@ -7,17 +7,16 @@ import org.springframework.beans.factory.annotation.Value
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class SswCrawler() {
+class SswCrawler {
     @Value("\${ssw.url}")
     lateinit var baseUrl: String
 
     fun consultarEntregas(cpfDestinatario: String): List<Entrega> {
-        val document = Jsoup.connect("${baseUrl}/2/resultSSW_dest")
+        return Jsoup.connect("${baseUrl}/2/resultSSW_dest")
                 .data("urlori", "/2/rastreamento_pf")
                 .data("cnpjdest", cpfDestinatario)
                 .post()
-
-        return document.select("a.email")
+                .select("a.email")
                 .map {
                     val onclickAttr = it.attr("onClick")
 
@@ -34,10 +33,8 @@ class SswCrawler() {
                                     td.select("p.tdb").text()
                                 }
 
-                                var titulo = linha.select("td")[2].select("p.titulo").text()
-
                                 Movimentacao(
-                                        titulo,
+                                        linha.select("td")[2].select("p.titulo").text() ?: "",
                                         LocalDateTime.parse(data, DateTimeFormatter.ofPattern("dd/MM/yy HH:mm")),
                                         unidade,
                                         detalhes


### PR DESCRIPTION
Criado crawler para buscar rastreios nos sites dos Correios. O site dos Correios só permite buscas por código de rastreio, portanto o crawler faz a busca de apenas um rastreio dado o código.